### PR TITLE
Fix: 2차 qa반영

### DIFF
--- a/app/koi-client/src/component-presentation/MobileLayout.tsx
+++ b/app/koi-client/src/component-presentation/MobileLayout.tsx
@@ -35,7 +35,7 @@ const MobileLayout = ({
             padding,
           }}
         >
-          <ScrollViewComponent>{children}</ScrollViewComponent>
+          <ScrollViewComponent disableInternalStyles>{children}</ScrollViewComponent>
         </TopScrollView>
       </Content>
     </Wrapper>

--- a/app/koi-client/src/component-presentation/ScrollView.tsx
+++ b/app/koi-client/src/component-presentation/ScrollView.tsx
@@ -11,10 +11,35 @@ export type ScrollViewProps = React.PropsWithChildren<{
   showScrollbar?: boolean;
 
   onScroll?: (args: React.UIEvent<HTMLDivElement, UIEvent>) => void;
+
+  /**
+   * 내부 스타일 적용 여부
+   * 사파리, 모바일 환경에서 모달이 헤더에 가려지는 문제
+   *
+   * @default false
+   */
+  disableInternalStyles?: boolean;
 }>;
 
-export const ScrollView = ({ showScrollbar = true, children, onScroll, ...props }: ScrollViewProps) => {
-  return (
+export const ScrollView = ({
+  showScrollbar = true,
+  children,
+  onScroll,
+  disableInternalStyles = false,
+  ...props
+}: ScrollViewProps) => {
+  return disableInternalStyles ? (
+    <div className={scrollViewStyle} {...props}>
+      <div className={viewportStyle} onScroll={onScroll}>
+        {children}
+      </div>
+      {showScrollbar && (
+        <div className={scrollbarStyle}>
+          <div className={thumbStyle} />
+        </div>
+      )}
+    </div>
+  ) : (
     <Radix.Root type="always" className={scrollViewStyle} data-f="SR-5f71" {...props}>
       <Radix.Viewport className={viewportStyle} onScroll={onScroll} data-f="SV-3fb5">
         {children}

--- a/app/koi-client/src/page/@backoffice@screen@[partyId]/component/StockScreen/Table.tsx
+++ b/app/koi-client/src/page/@backoffice@screen@[partyId]/component/StockScreen/Table.tsx
@@ -42,7 +42,7 @@ const Table = ({ stockId }: Props) => {
         const diff = timeIdx === 0 ? 0 : companies[company][timeIdx].가격 - companies[company][timeIdx - 1].가격;
         const 등락 =
           diff > 0 ? `▲${commaizeNumber(Math.abs(diff))}` : diff < 0 ? `▼${commaizeNumber(Math.abs(diff))}` : '-';
-        const color = diff > 0 ? '#60A5FA' : diff < 0 ? '#F87171' : undefined;
+        const color = diff > 0 ? '#F87171' : diff < 0 ? '#60A5FA' : undefined;
 
         return (
           <Row key={company}>


### PR DESCRIPTION
## 변경사항

### 1. 백오피스 등락 색상 변경

| 변경 전 | 변경 후 |
|---|---|
| <img width="1722" alt="Screenshot 2025-03-15 at 01 07 32" src="https://github.com/user-attachments/assets/ee0b079a-4009-4a3d-b61c-1ed88ca189ef" /> | <img width="1733" alt="Screenshot 2025-03-15 at 01 07 03" src="https://github.com/user-attachments/assets/578e14ee-8314-4624-b766-ff06ddc59c41" /> |

---

### 2. 모달이 헤더에 가려지는 이슈 해결

| 변경 전 | 변경 후 |
|---|---|
| <img width="713" alt="Screenshot 2025-03-15 at 01 08 51" src="https://github.com/user-attachments/assets/d6de9c48-830c-4c7a-825d-3c65127fc903" /> | <img width="717" alt="Screenshot 2025-03-15 at 01 08 19" src="https://github.com/user-attachments/assets/8faf7b14-5eb0-483d-b048-4cda5ec8aab5" /> |
