### PR TITLE
cursor rule 관련 경로를 gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,7 @@ turbo-build.log
 /blob-report/
 /playwright/.cache/
 
-# windsurf rules
+# IDE rules
 .windsurfrules
+.cursor/
+.cursorrules


### PR DESCRIPTION
## 변경 사항
gitignore에 cursor 관련 ai 규칙을 설정할 수 있는 경로를 추가했습니다.
- .cursor/rules: >= v0.46
- .cursorrules: < v0.46