### PR TITLE
refactor: stock, stockUser DB Collection 통합

### DIFF
--- a/app/koi-client/src/component/StockDetail/UserList.tsx
+++ b/app/koi-client/src/component/StockDetail/UserList.tsx
@@ -48,7 +48,6 @@ const UserList: React.FC<UserListProps> = ({ stockId }) => {
 
             mutateRegisterUser({
               stockId,
-              stockStorages: [],
               userId: profileData.id,
               userInfo: {
                 gender: profileData.gender,

--- a/app/sdc-sqs-worker/src/sqs-consumer/sqs-consumer.service.ts
+++ b/app/sdc-sqs-worker/src/sqs-consumer/sqs-consumer.service.ts
@@ -1,6 +1,6 @@
 import type { OnModuleInit } from '@nestjs/common';
 import { Injectable, Logger } from '@nestjs/common';
-import { StockProcessor, StockUser, UserProcessor } from 'feature-nest-stock';
+import { StockProcessor, UserProcessor } from 'feature-nest-stock';
 import { SqsService, SqsMessage } from 'lib-nest-sqs';
 import type { Request } from 'shared~type-stock';
 
@@ -21,9 +21,9 @@ export class SqsConsumerService implements OnModuleInit {
 
   async handleMessage(message: SqsMessage): Promise<void> {
     switch (message.action) {
-      case 'registerUser':
-        await this.handleUserRegistration(message.data as StockUser);
-        break;
+      // case 'registerUser':
+      //   await this.handleUserRegistration(message.data as StockUser);
+      //   break;
       case '/stock/buy': {
         const params = message.data as Request.PostBuyStock;
         await this.stockProcessor.buyStock(params.stockId, params, { queueMessageId: params.queueUniqueId });
@@ -90,8 +90,8 @@ export class SqsConsumerService implements OnModuleInit {
     }
   }
 
-  private async handleUserRegistration(userData: StockUser): Promise<void> {
-    this.logger.log(`사용자 등록 처리: ${userData.userId} (${userData.stockId})`);
-    await this.userProcessor.registerUser(userData);
-  }
+  // private async handleUserRegistration(userData: StockUser): Promise<void> {
+  //   this.logger.log(`사용자 등록 처리: ${userData.userId} (${userData.stockId})`);
+  //   await this.userProcessor.registerUser(userData);
+  // }
 }

--- a/package/feature/feature-nest-stock/src/stock.schema.ts
+++ b/package/feature/feature-nest-stock/src/stock.schema.ts
@@ -1,6 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument, SchemaTypes } from 'mongoose';
 import { CompanyInfo, StockPhase, StockSchema } from 'shared~type-stock';
+import { StockUser } from './user/user.schema';
 
 @Schema()
 export class Stock implements StockSchema {
@@ -31,6 +32,9 @@ export class Stock implements StockSchema {
   @Prop()
   round: number;
 
+  @Prop({ type: [StockUser] })
+  users: StockUser[];
+
   constructor() {
     this.stockPhase = 'CROWDING';
     this.startedTime = new Date();
@@ -41,6 +45,7 @@ export class Stock implements StockSchema {
     this.transactionInterval = 0;
     this.fluctuationsInterval = 5;
     this.round = 0;
+    this.users = [];
   }
 }
 

--- a/package/feature/feature-nest-stock/src/user/user.module.ts
+++ b/package/feature/feature-nest-stock/src/user/user.module.ts
@@ -2,18 +2,18 @@ import { Module, forwardRef } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { HttpModule } from '@nestjs/axios';
 import { UserService } from './user.service';
-import { StockUser, userSchema } from './user.schema';
 import { UserController } from './user.controller';
 import { UserRepository } from './user.repository';
 import { StockModule } from '../stock.module';
 import { UserProcessor } from './user.processor';
+import { Stock, stockSchema } from '../stock.schema';
 
 @Module({
   controllers: [UserController],
   exports: [UserService, UserRepository, UserProcessor],
   imports: [
     HttpModule,
-    MongooseModule.forFeature([{ name: StockUser.name, schema: userSchema }]),
+    MongooseModule.forFeature([{ name: Stock.name, schema: stockSchema }]),
     forwardRef(() => StockModule),
   ],
   providers: [UserService, UserRepository, UserProcessor],

--- a/package/feature/feature-nest-stock/src/user/user.processor.ts
+++ b/package/feature/feature-nest-stock/src/user/user.processor.ts
@@ -6,7 +6,8 @@ import { StockUser } from './user.schema';
 export class UserProcessor {
   constructor(private readonly userRepository: UserRepository) {}
 
+  // @FIXME: 현재 사용하지 않음
   async registerUser(user: StockUser): Promise<void> {
-    return this.userRepository.create(user);
+    // return this.userRepository.create(user);
   }
 }

--- a/package/feature/feature-nest-stock/src/user/user.schema.ts
+++ b/package/feature/feature-nest-stock/src/user/user.schema.ts
@@ -36,9 +36,6 @@ export class StockUserInfo implements StockUserInfoSchema {
 @Schema({ autoIndex: true })
 export class StockUser implements StockUserSchema {
   @Prop()
-  stockId: string;
-
-  @Prop()
   userId: string;
 
   @Prop({ type: StockUserInfo })
@@ -61,7 +58,6 @@ export class StockUser implements StockUserSchema {
 
   constructor(required: Pick<StockUserSchema, StockUserRequired>, partial: StockUserForm) {
     this.userId = required.userId;
-    this.stockId = required.stockId;
     this.userInfo = required.userInfo;
 
     this.index = partial.index ?? 0;
@@ -86,5 +82,5 @@ export type UserDocument = HydratedDocument<StockUser>;
 
 export const userSchema = SchemaFactory.createForClass(StockUser);
 
-// eslint-disable-next-line sort-keys-fix/sort-keys-fix
-userSchema.index({ stockId: 1, index: 1 });
+// 인덱스 수정 - stockId 제거됨
+userSchema.index({ index: 1 });

--- a/package/shared/type-stock/Request.ts
+++ b/package/shared/type-stock/Request.ts
@@ -67,4 +67,4 @@ export type PostSetStockPhase = {
 };
 
 export type PostCreateUser = Pick<StockUserSchema, StockUserRequired> &
-  Omit<Partial<StockUserSchema>, StockUserRequired>;
+  Omit<Partial<StockUserSchema>, StockUserRequired> & { stockId: string };

--- a/package/shared/type-stock/index.ts
+++ b/package/shared/type-stock/index.ts
@@ -1,7 +1,7 @@
 export type * as Request from './Request';
 export type * as Response from './Response';
 
-export type StockUserRequired = 'stockId' | 'userId' | 'userInfo';
+export type StockUserRequired = 'userId' | 'userInfo';
 export type StockUserOmitted = 'lastActivityTime';
 export type StockUserForm = Pick<StockUserSchema, StockUserRequired> &
   Partial<Omit<StockUserSchema, StockUserRequired | StockUserOmitted>>;
@@ -19,7 +19,6 @@ export type StockStorageSchema = {
 };
 
 export type StockUserSchema = {
-  stockId: string;
   userId: string;
   userInfo: StockUserInfoSchema;
   index: number;
@@ -65,6 +64,10 @@ export type StockSchema = {
    * 2라운드 - 본선게임
    */
   round: number;
+  /**
+   * 유저 정보 배열
+   */
+  users: StockUserSchema[];
 };
 export type StockSchemaWithId = StockSchema & { _id: string };
 


### PR DESCRIPTION
## 변경 사항
이 PR은 기존의 분리된 Stock과 StockUser 컬렉션을 단일 컬렉션 패턴으로 통합합니다.

### 주요 변경점:
- Stock 스키마에 `users` 배열 추가하여 StockUser 문서를 포함하도록 변경
- StockUser 스키마에서 `stockId` 필드 제거 (중복 정보 제거)
- UserRepository 메소드 인터페이스 변경
  - `find` → `findUsers`
  - `findOne` → `findUser`
  - `updateOne` → `updateUser` 등
- 데이터 접근 및 갱신 방식 변경
  - MongoDB의 배열 필터(`arrayFilters`)를 사용하여 중첩 문서 업데이트
  - 개별 save 호출 대신 Stock 문서 내 users 배열 직접 수정

### 기대 효과:
- **성능 향상**: 여러 컬렉션 조회 대신 단일 쿼리로 관련 데이터 접근 가능
- **데이터 일관성**: Stock과 관련 User 정보가 항상 함께 관리되어 일관성 유지
- **트랜잭션 간소화**: 단일 컬렉션 내에서 트랜잭션 처리로 복잡성 감소
- **메모리 효율성**: 중복 데이터(stockId) 제거로 메모리 사용량 최적화

### 관련 변경 파일:
- Stock 스키마 및 서비스
- StockUser 스키마 및 서비스
- StockProcessor 및 관련 메소드
- UserRepository 및 컨트롤러

### 테스트:
- 기존 기능이 모두 정상 작동하는지 확인
- 사용자 등록, 조회, 수정 및 삭제 기능 테스트
- 주식 거래와 관련된 사용자 정보 업데이트 테스트
